### PR TITLE
Dependabot and ruby update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,13 @@ AllCops:
   Exclude:
     - 'templates/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
+
+Metrics/CyclomaticComplexity:
+  Max: 10
 
 Metrics/MethodLength:
   Max: 50
@@ -22,3 +25,106 @@ Style/Documentation:
 Style/GuardClause:
   Exclude:
     - 'contur.gemspec'
+
+Layout/BeginEndAlignment:
+  Enabled: true
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/HashCompareByIdentity:
+  Enabled: true
+Lint/IdentityComparison:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/RedundantSafeNavigation:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
+Lint/UselessTimes:
+  Enabled: true
+Style/AccessorGrouping:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/ClassEqualityComparison:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/GlobalStdStream:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+Style/KeywordParametersOrder:
+  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/RedundantSelfAssignment:
+  Enabled: true
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: true
+Style/SoleNestedConditional:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: bundler
 services:
 - docker
 rvm:
-- 2.3.1
+- 2.6.0
 before_install:
-- gem install bundler -v '~> 1.13'
+- gem install bundler -v '~> 2.1'
 script:
 - bundle exec rake install
 - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in contur.gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+# Contur
+
 ![Contur Logo](contur-logo.png)
 
-# Contur
 Contur is an open-source command line application simplifying your local web development environment. It hosts your site using Docker containers so you don't have to install Apache, MySQL, PHP and PHP extensions on your own machine. Contur is written in Ruby and uses the Docker HTTP API.
 
 [![Gem Version](https://badge.fury.io/rb/contur.svg)](https://badge.fury.io/rb/contur)
@@ -8,14 +9,17 @@ Contur is an open-source command line application simplifying your local web dev
 [![Coverage Status](https://coveralls.io/repos/github/Cheppers/contur/badge.svg?branch=master)](https://coveralls.io/github/Cheppers/contur?branch=master)
 
 ## Requirements
-* Ruby 2.3.0+ (recommended installation method [via rvm](https://rvm.io/rvm/install))
+
+* Ruby 2.6.0+ (recommended installation method [via rvm](https://rvm.io/rvm/install))
 * Docker (for Mac see [this](https://docs.docker.com/engine/installation/mac/#/docker-for-mac))
 
 ## Installation
+
 1. Install requirements (see above)
 2. `gem install contur`
 
 ## Usage
+
 1. Create a `.contur.yml` file in the root of your repository
 2. Launch docker
 3. Run `$ contur start` to build the image, launch the MySQL container and the Contur container
@@ -37,6 +41,7 @@ When you run the `restart` command the following will happen:
 3. Contur starts a new container and re-runs the init script
 
 ## The container
+
 The following happens in the container when you start it:
 
 1. Export the specified envrionment variables (`env` section)
@@ -45,34 +50,42 @@ The following happens in the container when you start it:
 4. Starts php-fpm to keep alive the container
 
 ## The .contur.yml
+
 The build file consists of sections: `version`, `use`, `before`, `env`.
 The minimal YAML file for contur to work properly:
+
 ```yaml
 ---
 version: 1.0
 ```
 
 ## Sections of the build file
+
 ### version - [required]
+
 Version of the build file. Currently this is the only required section.
 
 Allowed values: `1.0`
 
-**Example**
+#### Example
+
 ```yaml
 ---
 version: 1.0
 ```
 
 ### use - [optional]
+
 Specify the MySQL and PHP versions you want to use.
 
 #### PHP
+
 Current default PHP version: **5.6.25**
 
 At the moment specifying a PHP version is not working (to be implemented soon).
 
 #### MySQL
+
 Default is the latest from Dockerhub
 
 To connect:
@@ -81,7 +94,8 @@ To connect:
 * password is 'admin'
 * host address: $MYSQL_PORT_3306_TCP_ADDR
 
-**Example**
+#### MySQL Example
+
 ```yaml
 ---
 version: 1.0
@@ -90,9 +104,11 @@ use:
 ```
 
 ### env - [optional]
+
 Specify environment variables to use them in the `before` script or in your site
 
-**Example**
+#### `env` Example
+
 ```yaml
 ---
 version: 1.0
@@ -102,9 +118,11 @@ env:
 ```
 
 ### before - [optional]
+
 Run scrips before starting php-fpm.
 
-**Example**
+#### `before` Example
+
 ```yaml
 ---
 version: 1.0
@@ -113,6 +131,7 @@ before:
 ```
 
 ## Example .contur.yml
+
 ```yaml
 ---
 version: 1.0
@@ -126,6 +145,7 @@ before:
 ```
 
 ## Commands
+
 ```bash
 $ contur help
 Commands:
@@ -143,18 +163,21 @@ Options:
 ```
 
 ## Near-future goals and features to be implemented
-- [ ] Selectable PHP version
-- [ ] Configurable port mapping for MySQL and your site
-- [ ] Multiple running environments
-- [ ] Ability to choose between Apache and Nginx for server
-- [ ] Ability to select/add PHP extensions
+
+* [ ] Selectable PHP version
+* [ ] Configurable port mapping for MySQL and your site
+* [ ] Multiple running environments
+* [ ] Ability to choose between Apache and Nginx for server
+* [ ] Ability to select/add PHP extensions
 
 ## Development
+
 After checking out the repo, run `bin/setup` to install dependencies.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
+
 1. Fork the repo
 2. Commit your changes to your own repo on a separate branch
 3. Submit pull request
@@ -162,7 +185,9 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 If you can, please use the provided [EditorConfig](http://editorconfig.org/) file!
 
 ## Milestones
+
 [List of Star Wars planets and moons](https://en.wikipedia.org/wiki/List_of_Star_Wars_planets_and_moons)
 
 ## License
+
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT). See more in LICENSE.txt

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -8,4 +9,4 @@ RuboCop::RakeTask.new(:rubocop) { |t| t.options << '-D' }
 RSpec::Core::RakeTask.new(:spec)
 Cucumber::Rake::Task.new(:features) { |t| t.cucumber_opts = '--format pretty' }
 
-task default: [:rubocop, :spec, :features]
+task default: %i[rubocop spec features]

--- a/bin/contur
+++ b/bin/contur
@@ -36,7 +36,7 @@ class ConturCLI < Thor
       puts 'Image built successfully'.green
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def run_container(restart: false, options: {})
       if (c = Contur::Controller.container?) && restart
         Contur::Controller.delete_container
@@ -58,6 +58,7 @@ class ConturCLI < Thor
       puts 'Container started'.green
       puts "Container id: #{Contur::Controller.container_id}" if options[:verbose]
     end
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def delete_mysql_containers
       if Contur::Controller.delete_mysql_containers
@@ -87,7 +88,7 @@ class ConturCLI < Thor
   class_option :verbose, type: :boolean, aliases: '-v'
   class_option :force, type: :boolean, aliases: '-f'
 
-  map %w(--version -V) => :__print_version
+  map %w[--version -V] => :__print_version
   desc '--version, -V', 'Current version'
   def __print_version
     puts Contur::VERSION
@@ -130,8 +131,7 @@ class ConturCLI < Thor
     puts delete_image if options[:image]
 
     puts delete_mysql_containers if options['mysql-container']
-
-  rescue => e
+  rescue StandardError => e
     puts e.message.red
     exit 1
   end
@@ -206,5 +206,6 @@ class ConturCLI < Thor
     puts "The changes will take effect after you restart your terminal or do a `source #{zshrc}`"
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/ClassLength
 
 ConturCLI.start(ARGV)

--- a/contur.gemspec
+++ b/contur.gemspec
@@ -1,8 +1,8 @@
-# coding: utf-8
 # frozen_string_literal: true
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require_relative 'lib/contur/version.rb'
+require_relative 'lib/contur/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'contur'
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.description   = IO.read('README.md').match(/# Contur\n^(?<desc>.*)$/)[:desc]
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
@@ -28,18 +28,18 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize', '~> 0.8'
-  spec.add_dependency 'excon', '~> 0.46', '>= 0.46'
   spec.add_dependency 'docker-api', '~> 1.31', '>= 1.31'
+  spec.add_dependency 'excon', '~> 0.71.0'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'thor-zsh_completion', '~> 0.1.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.51'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'cucumber', '~> 2.4'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'cucumber', '~> 2.4'
+  spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 0.51'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'simplecov-console', '~> 0.3'
 end

--- a/features/step_definitions/init_steps.rb
+++ b/features/step_definitions/init_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Given(/^I have an empty directory$/) do
   expect(Dir.entries(@tmpdir).size).to eq 2
 end

--- a/features/step_definitions/version_steps.rb
+++ b/features/step_definitions/version_steps.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 When(/^I call "([^"]*)"$/) do |version_command|
   @response = `#{version_command}`
   expect(@response).to_not be_nil

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fileutils'
 require 'rspec'
 require 'English'

--- a/lib/contur.rb
+++ b/lib/contur.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'contur/version'
 
 # require application files

--- a/lib/contur/bindable_hash.rb
+++ b/lib/contur/bindable_hash.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Contur module :D
 module Contur
   # BindableHash is for ERB templates

--- a/lib/contur/config.rb
+++ b/lib/contur/config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'contur/config/before'
 require 'contur/config/env'
 require 'contur/config/errors'
@@ -50,6 +51,7 @@ module Contur
       instance_variables.each do |var|
         section = instance_variable_get(var)
         next unless section.respond_to?(:name) && section.respond_to?(:errors)
+
         section_name = section.send(:name)
         section_errors = section.send(:errors)
         section_errors.each do |err|

--- a/lib/contur/config/before.rb
+++ b/lib/contur/config/before.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Contur
   class Config
     # Before section

--- a/lib/contur/config/env.rb
+++ b/lib/contur/config/env.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Contur
   class Config
     # Env section

--- a/lib/contur/config/errors.rb
+++ b/lib/contur/config/errors.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Contur
   class Config
     # NotFoundError

--- a/lib/contur/config/use.rb
+++ b/lib/contur/config/use.rb
@@ -25,6 +25,7 @@ module Contur
       def validate!(using)
         @errors = []
         return unless using.respond_to? :keys
+
         extra_keys = using.keys - ALLOWED_VALUES
         extra_keys.each do |key|
           @errors << "Unknown key: #{key}"

--- a/lib/contur/config/version.rb
+++ b/lib/contur/config/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Contur
   class Config
     # Version section

--- a/lib/contur/utils.rb
+++ b/lib/contur/utils.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Contur
   # Utils class
   class Utils

--- a/spec/contur/bindable_hash_spec.rb
+++ b/spec/contur/bindable_hash_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'contur/bindable_hash'
 
 describe Contur::BindableHash do
@@ -12,7 +13,7 @@ describe Contur::BindableHash do
 
   it '#get_binding' do
     bind = subject.get_binding
-    expect(eval('firstvalue', bind)).to be 1
-    expect(eval('secondvalue', bind)).to eq 'two'
+    expect(eval('firstvalue', bind, __FILE__, __LINE__)).to be 1
+    expect(eval('secondvalue', bind, __FILE__, __LINE__)).to eq 'two'
   end
 end

--- a/spec/contur/config_spec.rb
+++ b/spec/contur/config_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'contur/config'
 require 'contur/config/errors'
 
@@ -12,14 +13,14 @@ describe Contur::Config do
 
   context '#new' do
     it 'with a valid file' do
-      valid_config_content = <<-EOF
----
-version: 1.0
-env:
-  TEST_VAR: test
-before:
-  - echo "TEST"
-      EOF
+      valid_config_content = <<~END_OF_CONTENT
+        ---
+        version: 1.0
+        env:
+          TEST_VAR: test
+        before:
+          - echo "TEST"
+      END_OF_CONTENT
 
       file = write_config_to_file(valid_config_content)
       cfg = Contur::Config.new(file.path)
@@ -46,12 +47,12 @@ before:
   end
 
   it '#errors' do
-    wrong_version_content = <<-EOF
----
-version: 2.1
-use:
-  nginx: 1.9.11
-    EOF
+    wrong_version_content = <<~END_OF_CONTENT
+      ---
+      version: 2.1
+      use:
+        nginx: 1.9.11
+    END_OF_CONTENT
 
     file = write_config_to_file(wrong_version_content)
     cfg = Contur::Config.new(file.path)
@@ -64,20 +65,20 @@ use:
   end
 
   it '#init_script' do
-    config_content = <<-EOF
----
-version: 1.0
-env:
-  TEST_VAR: test
-before:
-  - echo "TEST"
-    EOF
+    config_content = <<~END_OF_CONTENT
+      ---
+      version: 1.0
+      env:
+        TEST_VAR: test
+      before:
+        - echo "TEST"
+    END_OF_CONTENT
 
     file = write_config_to_file(config_content)
     cfg = Contur::Config.new(file.path)
 
     expect(cfg.errors).to be_empty
-    config_regex = /echo \"Generated at: \[.*\]\"\s+export TEST_VAR=\"test\"\necho \"TEST\"/
+    config_regex = /echo "Generated at: \[.*\]"\s+export TEST_VAR="test"\necho "TEST"/
     expect(cfg.init_script).to match config_regex
 
     file.delete
@@ -85,24 +86,24 @@ before:
 
   context '#inspect' do
     it 'with default values' do
-      config_content = <<-EOF
----
-version: 1.0
-env:
-  TEST_VAR: test
-before:
-  - echo "TEST"
-      EOF
+      config_content = <<~END_OF_CONTENT
+        ---
+        version: 1.0
+        env:
+          TEST_VAR: test
+        before:
+          - echo "TEST"
+      END_OF_CONTENT
 
       file = write_config_to_file(config_content)
       cfg = Contur::Config.new(file.path)
 
-      inspected_cfg = <<-EOF
-Section 'version': 1.0
-Section 'use': {"php"=>"5.6", "mysql"=>"latest"}
-Section 'env': {"TEST_VAR"=>"test"}
-Section 'before': [\"echo \\\"TEST\\\"\"]
-      EOF
+      inspected_cfg = <<~END_OF_CONFIG
+        Section 'version': 1.0
+        Section 'use': {"php"=>"5.6", "mysql"=>"latest"}
+        Section 'env': {"TEST_VAR"=>"test"}
+        Section 'before': [\"echo \\\"TEST\\\"\"]
+      END_OF_CONFIG
       inspected_cfg = inspected_cfg.chomp
 
       expect(cfg.errors).to be_empty
@@ -112,27 +113,28 @@ Section 'before': [\"echo \\\"TEST\\\"\"]
     end
 
     it 'with explicit values' do
-      config_content = <<-EOF
----
-version: 1.0
-use:
-  php: 7.1
-  mysql: 5.5.25
-env:
-  TEST_VAR: test
-before:
-  - echo "TEST"
-      EOF
+      config_content = <<~END_OF_CONTENT
+        ---
+        version: 1.0
+        use:
+          php: 7.1
+          mysql: 5.5.25
+        env:
+          TEST_VAR: test
+        before:
+          - echo "TEST"
+      END_OF_CONTENT
 
       file = write_config_to_file(config_content)
       cfg = Contur::Config.new(file.path)
 
-      inspected_cfg = <<-EOF
-Section 'version': 1.0
-Section 'use': {"php"=>7.1, "mysql"=>"5.5.25"}
-Section 'env': {"TEST_VAR"=>"test"}
-Section 'before': [\"echo \\\"TEST\\\"\"]
-      EOF
+      inspected_cfg = <<~END_OF_CONFIG
+        Section 'version': 1.0
+        Section 'use': {"php"=>7.1, "mysql"=>"5.5.25"}
+        Section 'env': {"TEST_VAR"=>"test"}
+        Section 'before': [\"echo \\\"TEST\\\"\"]
+      END_OF_CONFIG
+
       inspected_cfg = inspected_cfg.chomp
 
       expect(cfg.errors).to be_empty

--- a/spec/contur/controller_spec.rb
+++ b/spec/contur/controller_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'yaml'
 require 'contur/controller'
 

--- a/spec/contur/utils_spec.rb
+++ b/spec/contur/utils_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'contur/utils'
 
 describe Contur::Utils do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'coveralls'
 require 'simplecov'


### PR DESCRIPTION
**Dependabot warnings:**

* CVE-2019-16779 _(Low severity)_: **excon < 0.71.0**
* CVE-2020-8130 _(Moderate severity)_: **rake <= 12.3.2**

**Update ruby:**

Ruby 2.3 is very old and should not be supported anymore. The official
EOL was March 31, 2019, it was like two years ago.

Extended the rubocop file to include all extra tests we did not have.
Now I enabled all of them.

Fixed all rubocop offenses.

**References:**

* Ruby Lifecycle (EOL): https://endoflife.software/programming-languages/server-side-scripting/ruby
* CVE-2019-16779: http://cve.circl.lu/cve/CVE-2019-16779
* CVE-2020-8130: http://cve.circl.lu/cve/CVE-2020-8130